### PR TITLE
Add RAG demo skeleton with unified config and React UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # kb_test
+
+This repository provides a skeleton for a local RAG demo comparing three Python stacks: LangChain, LlamaIndex, and Haystack. A unified configuration file (`config/config.yaml`) controls loaders, chunking, embeddings, vector store options, retrieval parameters, and LLM settings. Each stack reads from this config so that only implementation details differ.
+
+## Structure
+
+- `config/config.yaml` – shared parameters
+- `src/` – minimal pipeline definitions for each framework
+- `web/` – placeholder React interface to chat with the three pipelines and trigger knowledge-base builds
+
+The code is illustrative and relies on external dependencies that are not installed in this environment. Real implementations would need additional error handling and API endpoints to connect the React interface with backend pipelines.
+

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,20 @@
+loaders:
+  directory: ./data
+  pattern: "*.txt"
+chunking:
+  chunk_size: 500
+  overlap: 50
+embedding:
+  model: sentence-transformers/all-MiniLM-L6-v2
+vector_store:
+  type: faiss
+  dimension: 384
+  metric: cosine
+retrieval:
+  top_k: 5
+  reranker: null
+  hybrid: false
+llm:
+  provider: openai
+  model: gpt-3.5-turbo
+  temperature: 0.7

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,17 @@
+"""Entry point for building and querying three RAG pipelines."""
+
+from . import langchain_pipeline, llamaindex_pipeline, haystack_pipeline
+
+PIPELINES = {
+    "langchain": langchain_pipeline,
+    "llamaindex": llamaindex_pipeline,
+    "haystack": haystack_pipeline,
+}
+
+
+def query(pipeline: str, question: str) -> str:
+    """Route query to the selected pipeline."""
+    if pipeline not in PIPELINES:
+        raise ValueError(f"Unknown pipeline {pipeline}")
+    return PIPELINES[pipeline].query(question)
+

--- a/src/common.py
+++ b/src/common.py
@@ -1,0 +1,13 @@
+"""Common utilities for loading configuration."""
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def load_config(path: str = "config/config.yaml") -> Dict[str, Any]:
+    """Load YAML configuration file."""
+    with open(Path(path), "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+

--- a/src/haystack_pipeline.py
+++ b/src/haystack_pipeline.py
@@ -1,0 +1,34 @@
+"""Haystack-based RAG pipeline."""
+
+# Placeholder imports
+try:
+    from haystack import Document
+    from haystack.nodes import EmbeddingRetriever, FARMReader
+    from haystack.document_stores import FAISSDocumentStore
+    from haystack.pipelines import ExtractiveQAPipeline
+except Exception:  # pragma: no cover - dependency not installed
+    Document = EmbeddingRetriever = FARMReader = FAISSDocumentStore = ExtractiveQAPipeline = None
+
+from .common import load_config
+
+
+def build_document_store() -> "FAISSDocumentStore":
+    cfg = load_config()
+    store = FAISSDocumentStore(embedding_dim=cfg["vector_store"]["dimension"], similarity=cfg["vector_store"]["metric"])
+    retriever = EmbeddingRetriever(
+        document_store=store,
+        embedding_model=cfg["embedding"]["model"],
+        top_k=cfg["retrieval"]["top_k"],
+    )
+    # Loading documents is left as an exercise; placeholder
+    return store
+
+
+def query(question: str) -> str:
+    cfg = load_config()
+    store = build_document_store()
+    reader = FARMReader(model_name_or_path=cfg["llm"]["model"])
+    pipeline = ExtractiveQAPipeline(reader, None)
+    result = pipeline.run(query=question, params={"Retriever": {"top_k": cfg["retrieval"]["top_k"]}})
+    return str(result)
+

--- a/src/langchain_pipeline.py
+++ b/src/langchain_pipeline.py
@@ -1,0 +1,42 @@
+"""LangChain-based RAG pipeline."""
+
+from typing import List
+
+# Placeholders for actual LangChain imports
+try:
+    from langchain.document_loaders import DirectoryLoader
+    from langchain.text_splitter import RecursiveCharacterTextSplitter
+    from langchain.embeddings import HuggingFaceEmbeddings
+    from langchain.vectorstores import FAISS
+    from langchain.chat_models import ChatOpenAI
+    from langchain.chains import RetrievalQA
+except Exception:  # pragma: no cover - dependency not installed
+    DirectoryLoader = RecursiveCharacterTextSplitter = HuggingFaceEmbeddings = None
+    FAISS = ChatOpenAI = RetrievalQA = None
+
+from .common import load_config
+
+
+def build_vector_store() -> "FAISS":
+    """Build FAISS vector store using LangChain based on shared config."""
+    cfg = load_config()
+    loader = DirectoryLoader(cfg["loaders"]["directory"], glob=cfg["loaders"]["pattern"])
+    docs = loader.load()
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=cfg["chunking"]["chunk_size"],
+        chunk_overlap=cfg["chunking"]["overlap"],
+    )
+    chunks = splitter.split_documents(docs)
+    embeddings = HuggingFaceEmbeddings(model_name=cfg["embedding"]["model"])
+    return FAISS.from_documents(chunks, embeddings)
+
+
+def query(question: str) -> str:
+    """Query the LangChain vector store with a question."""
+    cfg = load_config()
+    store = build_vector_store()
+    retriever = store.as_retriever(search_type="similarity", search_kwargs={"k": cfg["retrieval"]["top_k"]})
+    llm = ChatOpenAI(model_name=cfg["llm"]["model"], temperature=cfg["llm"]["temperature"])
+    chain = RetrievalQA.from_chain_type(llm, retriever=retriever)
+    return chain.run(question)
+

--- a/src/llamaindex_pipeline.py
+++ b/src/llamaindex_pipeline.py
@@ -1,0 +1,30 @@
+"""LlamaIndex-based RAG pipeline."""
+
+# Placeholder imports
+try:
+    from llama_index import SimpleDirectoryReader, VectorStoreIndex, ServiceContext
+    from llama_index.llms import OpenAI
+    from llama_index.embeddings import HuggingFaceEmbedding
+except Exception:  # pragma: no cover - dependency not installed
+    SimpleDirectoryReader = VectorStoreIndex = ServiceContext = None
+    OpenAI = HuggingFaceEmbedding = None
+
+from .common import load_config
+
+
+def build_index() -> "VectorStoreIndex":
+    cfg = load_config()
+    reader = SimpleDirectoryReader(cfg["loaders"]["directory"], recursive=True)
+    docs = reader.load_data()
+    embed_model = HuggingFaceEmbedding(model_name=cfg["embedding"]["model"])
+    service_context = ServiceContext.from_defaults(embed_model=embed_model, chunk_size=cfg["chunking"]["chunk_size"])
+    return VectorStoreIndex.from_documents(docs, service_context=service_context)
+
+
+def query(question: str) -> str:
+    cfg = load_config()
+    index = build_index()
+    query_engine = index.as_query_engine(similarity_top_k=cfg["retrieval"]["top_k"])
+    response = query_engine.query(question)
+    return str(response)
+

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "rag-demo",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "echo 'React app placeholder'",
+    "test": "echo 'No tests defined'"
+  }
+}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>RAG Demo</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+function ChatPanel({ label, pipeline }) {
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+
+  const handleAsk = () => {
+    // Placeholder: in real app, call backend API
+    setAnswer(`Placeholder answer from ${pipeline}: ${question}`);
+  };
+
+  return (
+    <div>
+      <h2>{label}</h2>
+      <input value={question} onChange={e => setQuestion(e.target.value)} />
+      <button onClick={handleAsk}>Ask</button>
+      <p>{answer}</p>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <div>
+      <h1>RAG Demo</h1>
+      <ChatPanel label="LangChain" pipeline="langchain" />
+      <ChatPanel label="LlamaIndex" pipeline="llamaindex" />
+      <ChatPanel label="Haystack" pipeline="haystack" />
+      <button>Build Knowledge Bases</button>
+    </div>
+  );
+}
+

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+


### PR DESCRIPTION
## Summary
- add shared config for loaders, chunking, embedding, vector store, retrieval and llm params
- scaffold LangChain, LlamaIndex and Haystack pipelines using the shared config
- create placeholder React UI to chat with each pipeline and trigger build

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689da970b4cc8329bc7bad5f5c7142cc